### PR TITLE
:sparkles: Implemented Fluent FFMPEG in place of manually specifying FFMPEG Flags

### DIFF
--- a/core/stream.js
+++ b/core/stream.js
@@ -1,45 +1,69 @@
 const fs = require('fs')
-const {Writable} = require('stream')
+const {Writable, PassThrough} = require('stream')
 const {spawn} = require('child_process')
-const {fps, logFile} = require('../config')
+const ffmpeg = require('fluent-ffmpeg')
 
-const ffmpegFlags = [
-  '-threads',
-  '0',
-  '-y',
-  '-v',
-  'verbose',
-  '-c:v',
-  'png',
-  '-r',
-  fps,
-  '-f',
-  'image2pipe',
-  '-i',
-  '-',
-  '-f',
-  'lavfi',
-  '-i',
-  'anullsrc',
-  '-acodec',
-  'aac',
-  '-ac',
-  '1',
-  '-ar',
-  '44100',
-  '-b:a',
-  '128k',
-  '-c:v',
-  'libx264',
-  '-s',
-  `1280x720`,
-  '-pix_fmt',
-  'yuv420p',
-  '-f',
-  'flv'
-]
+const {fps, logFile, size: {width, height}} = require('../config')
 
 const logStream = fs.createWriteStream(logFile)
+
+// prettier-ignore
+const ffmpegFlags = [
+  '-threads', '0',
+  '-y',
+  '-v', 'verbose',
+
+  '-c:v', 'png',
+  '-r', fps,
+  '-f', 'image2pipe',
+  '-i', '-',
+  '-f', 'lavfi',
+  '-i', 'anullsrc',
+
+  '-acodec', 'aac',
+  '-ac', '1',
+  '-ar', '44100',
+  '-b:a', '128k',
+  '-c:v', 'libx264',
+  '-s', `${width}x${height}`,
+  '-pix_fmt', 'yuv420p',
+  '-f', 'flv'
+]
+
+// .input('-', this.input)
+// .fps(fps)
+// .inputFormat('image2pipe')
+// .inputFormat('lavfi')
+// .videoCodec('png')
+// .input('anullsrc')
+// .audioCodec('aac')
+// .audioChannels(1)
+// .audioFrequency(44100)
+// .audioBitrate(128)
+// .videoCodec('libx264')
+// .size('1280x720')
+// .outputOptions('-pix_fmt', 'yuv420p')
+// .format('flv')
+
+// this.input = new PassThrough()
+
+// const command = ffmpeg(this.input)
+//   .format('flv')
+//   .size('1280x720')
+//   .videoCodec('libx264')
+//   .fps(fps)
+//   .audioBitrate(128)
+//   .audioCodec('aac')
+//   .audioFrequency(44100)
+//   .audioChannels(2)
+//   .output(rtmpUrl)
+//   .on('error', err => console.error('FFMPEG Error:', err))
+//   .on('data', data => console.info('FFMPEG Data:', data))
+//   .on('end', () => console.info('Finished Processing...'))
+//
+// console.info('ffmpeg', command._getArguments().join(' '))
+//
+// command.run()
 
 class VideoStream extends Writable {
   constructor(rtmpUrl) {
@@ -49,7 +73,7 @@ class VideoStream extends Writable {
     this.ffmpeg = spawn('ffmpeg', args, {stdio})
   }
 
-  write(buffer, encoding, callback) {
+  write(buffer) {
     this.ffmpeg.stdin.write(buffer)
   }
 }

--- a/core/stream.js
+++ b/core/stream.js
@@ -3,78 +3,67 @@ const {Writable, PassThrough} = require('stream')
 const {spawn} = require('child_process')
 const ffmpeg = require('fluent-ffmpeg')
 
-const {fps, logFile, size: {width, height}} = require('../config')
+const {fps, logFile, size} = require('../config')
 
 const logStream = fs.createWriteStream(logFile)
 
 // prettier-ignore
-const ffmpegFlags = [
-  '-threads', '0',
-  '-y',
-  '-v', 'verbose',
-
-  '-c:v', 'png',
-  '-r', fps,
-  '-f', 'image2pipe',
-  '-i', '-',
-  '-f', 'lavfi',
-  '-i', 'anullsrc',
-
-  '-acodec', 'aac',
-  '-ac', '1',
-  '-ar', '44100',
-  '-b:a', '128k',
-  '-c:v', 'libx264',
-  '-s', `${width}x${height}`,
-  '-pix_fmt', 'yuv420p',
-  '-f', 'flv'
+const customFlags = [
+  '-threads', '0',  // Threads: 0
+  '-y',             // Replace Existing File
+  '-v', 'verbose',  // Logging Level: Verbose
 ]
 
-// .input('-', this.input)
-// .fps(fps)
-// .inputFormat('image2pipe')
-// .inputFormat('lavfi')
-// .videoCodec('png')
-// .input('anullsrc')
-// .audioCodec('aac')
-// .audioChannels(1)
-// .audioFrequency(44100)
-// .audioBitrate(128)
-// .videoCodec('libx264')
-// .size('1280x720')
-// .outputOptions('-pix_fmt', 'yuv420p')
-// .format('flv')
-
-// this.input = new PassThrough()
-
-// const command = ffmpeg(this.input)
-//   .format('flv')
-//   .size('1280x720')
-//   .videoCodec('libx264')
-//   .fps(fps)
-//   .audioBitrate(128)
-//   .audioCodec('aac')
-//   .audioFrequency(44100)
-//   .audioChannels(2)
-//   .output(rtmpUrl)
-//   .on('error', err => console.error('FFMPEG Error:', err))
-//   .on('data', data => console.info('FFMPEG Data:', data))
-//   .on('end', () => console.info('Finished Processing...'))
-//
-// console.info('ffmpeg', command._getArguments().join(' '))
-//
-// command.run()
-
+// prettier-ignore
 class VideoStream extends Writable {
   constructor(rtmpUrl) {
     super()
-    const args = [...ffmpegFlags, rtmpUrl]
-    const stdio = ['pipe', 1, 2, 'ipc']
-    this.ffmpeg = spawn('ffmpeg', args, {stdio})
+
+    // Input Stream
+    this.input = new PassThrough()
+
+    // Video Input
+    // Codec: PNG
+    // Format: Image to Pipe
+    const input = ffmpeg({logger: console})
+      .input(this.input)
+      .inputOptions(customFlags)
+      .inputOptions('-c:v', 'png')
+      .inputFPS(fps)
+      .inputFormat('image2pipe')
+
+    // Audio Settings
+    // Source: Null Audio Source
+    // Input Format: LibAV Virtual Input
+    const audio = input
+      .input('anullsrc')
+      .inputFormat('lavfi')
+      .audioCodec('aac')
+      .audioChannels(1)
+      .audioFrequency(44100)
+      .audioBitrate(128)
+
+    // Video Output
+    // Codec: H264 (libx264)
+    // Output: RTMP Stream to Facebook Live
+    // Pix Format: YUV420P
+    const output = audio
+      .addOption('-c:v', 'libx264')
+      .size(`${size.width}x${size.height}`)
+      .addOption('-pix_fmt', 'yuv420p')
+      .format('flv')
+      .output(rtmpUrl)
+
+    const instance = output
+      .on('data', data => console.info('On Data', data))
+      .on('error', err => console.warn('On Error', err))
+      .on('end', () => console.info('On End', data))
+
+    instance.run()
   }
 
   write(buffer) {
-    this.ffmpeg.stdin.write(buffer)
+    this.input.write(buffer)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.4.6",
+    "fluent-ffmpeg": "^2.1.2",
     "puppeteer": "^0.11.0",
     "request": "^2.78.0",
     "request-promise": "^4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,6 +29,12 @@ async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
 
+async@>=0.2.9:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
+  dependencies:
+    lodash "^4.14.0"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -175,6 +181,13 @@ fd-slicer@~1.0.1:
   dependencies:
     pend "~1.2.0"
 
+fluent-ffmpeg@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fluent-ffmpeg/-/fluent-ffmpeg-2.1.2.tgz#c952de2240f812ebda0aa8006d7776ee2acf7d74"
+  dependencies:
+    async ">=0.2.9"
+    which "^1.1.1"
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -266,6 +279,10 @@ isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -305,7 +322,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-lodash@^4.13.1:
+lodash@^4.13.1, lodash@^4.14.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -539,6 +556,12 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+which@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  dependencies:
+    isexe "^2.0.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
This allows us to use the excellent fluent-ffmpeg library in place of manually specifying flags in an array, which is seriously prone to error.

Before:
```
const ffmpegFlags = [
  '-c:v', 'png',
  '-r', fps,
  '-f', 'image2pipe',
  '-i', '-',
  '-f', 'lavfi',
  '-i', 'anullsrc',
  '-acodec', 'aac',
  '-ac', '1',
  '-ar', '44100',
  '-b:a', '128k',
  '-c:v', 'libx264',
  '-s', 1280x720,
  '-pix_fmt', 'yuv420p',
  '-f', 'flv'
]
```

After:
```
const input = ffmpeg({logger: console})
  .input(this.input)
  .inputOptions(customFlags)
  .inputOptions('-c:v', 'png')
  .inputFPS(fps)
  .inputFormat('image2pipe')

// Audio Settings
// Source: Null Audio Source
// Input Format: LibAV Virtual Input
const audio = input
  .input('anullsrc')
  .inputFormat('lavfi')
  .audioCodec('aac')
  .audioChannels(1)
  .audioFrequency(44100)
  .audioBitrate(128)

// Video Output
// Codec: H264 (libx264)
// Output: RTMP Stream to Facebook Live
const output = audio
  .addOption('-c:v', 'libx264')
  .size(`${size.width}x${size.height}`)
  .addOption('-pix_fmt', 'yuv420p')
  .format('flv')
  .output(rtmpUrl)
```